### PR TITLE
`htmlFor` -> `for_`

### DIFF
--- a/ppx/Ppx_html.ml
+++ b/ppx/Ppx_html.ml
@@ -720,7 +720,7 @@ let keygenHTMLAttributes =
 let labelHTMLAttributes =
   [
     Attribute { name = "form"; jsxName = "form"; type_ = String };
-    Attribute { name = "for"; jsxName = "htmlFor"; type_ = String };
+    Attribute { name = "for"; jsxName = "for_"; type_ = String };
   ]
 
 (* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li *)
@@ -832,7 +832,7 @@ let optionHTMLAttributes =
 let outputHTMLAttributes =
   [
     Attribute { name = "form"; jsxName = "form"; type_ = String };
-    Attribute { name = "for"; jsxName = "htmlFor"; type_ = String };
+    Attribute { name = "for"; jsxName = "for_"; type_ = String };
     Attribute { name = "name"; jsxName = "name"; type_ = String };
   ]
 


### PR DESCRIPTION
Should it be like this?

This line is a bit deceptive 😏 

<img width="542" alt="image" src="https://github.com/davesnx/html_of_jsx/assets/17602389/e17a5119-c6fe-4d87-85d6-f6e3c36e65a5">
