### PR TITLE
Improvements

### DIFF
--- a/demo/dune
+++ b/demo/dune
@@ -4,13 +4,3 @@
  (libraries tiny_httpd html_of_jsx)
  (preprocess
   (pps html_of_jsx.ppx -htmx)))
-
-(melange.emit
- (modules client)
- (target output)
- (alias demo)
- (libraries html_of_jsx)
- (preprocess
-  (pps html_of_jsx.ppx))
- (module_systems
-  (es6 mjs)))

--- a/docs/index.mld
+++ b/docs/index.mld
@@ -4,14 +4,14 @@
 
 {3 Render HTML with JSX}
 
-{b html_of_jsx} is a JSX transformation to write HTML declaratively in {{:https://ocaml.org OCaml}, {{:https://reasonml.github.io} Reason} and {{:https://github.com/ocaml-mlx/mlx}mlx}.
+{b html_of_jsx} is a JSX transformation to write HTML declaratively in {{:https://ocaml.org}OCaml}, {{:https://reasonml.github.io}Reason} and {{:https://github.com/ocaml-mlx/mlx}mlx}.
 
 This library was extracted from {{: https://github.com/ml-in-barcelona/server-reason-react} server-reason-react} and later simplified to work only with HTML5.
 
 {1 Installation}
 
 {[
-opan install html_of_jsx
+opam install html_of_jsx
 ]}
 
 {3 Add it to your `dune` file}

--- a/docs/index.mld
+++ b/docs/index.mld
@@ -32,7 +32,6 @@ The only module exposed is {!JSX} with some functions to construct elements and 
 - Integrates well with Htmx (see the {!page-"htmx"} page)
 - No React idioms (no [className], no [htmlFor], no [onChange], etc...), just plain HTML5
 - Type-safe, validates attributes and their types
-- Works with {{:https://ocaml.org OCaml}, {{:https://reasonml.github.io} Reason} and {{:https://github.com/ocaml-mlx/mlx}mlx}
-- Created to work on the server-side, but can be used on the client-side too (with {{:https://melange.re} Melange})
+- Works with {{:https://ocaml.org} OCaml}, {{:https://reasonml.github.io} Reason} and {{:https://github.com/ocaml-mlx/mlx}mlx}
 
 {b See the {!page-"features"} page for all details}

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,6 @@
 (lang dune 3.12)
 (generate_opam_files true)
 (implicit_transitive_deps false)
-(using melange 0.1)
 
 (name html_of_jsx)
 (maintainers "David Sancho <dsnxmoreno@gmail.com>")
@@ -18,13 +17,12 @@
  (description "html_of_jsx is a JSX transformation that allows you to write HTML declaratively.")
  (depends
   (ocaml (>= 4.14))
-  (reason (>= 3.10.0))
   (ppxlib (> 0.23.0))
-  melange
 
   ;; Test dependencies
   (alcotest :with-test)
   (benchmark :with-test)
+  (reason (and (>= 3.10.0) :with-test))
 
   ;; Documentation
   (odoc :with-doc)

--- a/dune-project
+++ b/dune-project
@@ -33,5 +33,5 @@
     (= 0.26.1) (or
     :with-dev-setup :with-test)))
   (ocaml-lsp-server :with-dev-setup)
-  (tiny_httpd :with-dev-setup)
+  (tiny_httpd (and (<= 0.16) :with-dev-setup))
 ))

--- a/html_of_jsx.opam
+++ b/html_of_jsx.opam
@@ -18,7 +18,7 @@ depends: [
   "odoc" {with-doc}
   "ocamlformat" {= "0.26.1" & (with-dev-setup | with-test)}
   "ocaml-lsp-server" {with-dev-setup}
-  "tiny_httpd" {with-dev-setup}
+  "tiny_httpd" {<= "0.16" & with-dev-setup}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/html_of_jsx.opam
+++ b/html_of_jsx.opam
@@ -11,11 +11,10 @@ bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
 depends: [
   "dune" {>= "3.12"}
   "ocaml" {>= "4.14"}
-  "reason" {>= "3.10.0"}
   "ppxlib" {> "0.23.0"}
-  "melange"
   "alcotest" {with-test}
   "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
   "odoc" {with-doc}
   "ocamlformat" {= "0.26.1" & (with-dev-setup | with-test)}
   "ocaml-lsp-server" {with-dev-setup}

--- a/lib/JSX.ml
+++ b/lib/JSX.ml
@@ -1,3 +1,5 @@
+module Html = Html
+
 module Attribute = struct
   (** Used internally, no need to use *)
 

--- a/lib/JSX.mli
+++ b/lib/JSX.mli
@@ -104,3 +104,5 @@ module Debug : sig
      ]}
   *)
 end
+
+module Html : module type of Html

--- a/lib/JSX.mli
+++ b/lib/JSX.mli
@@ -73,21 +73,20 @@ val unsafe : string -> element
 
 (** Provides ways to inspect a JSX.element. *)
 module Debug : sig
-  type __node = {
-    tag : string;
-    attributes : Attribute.t list;
-    children : __element list;
-  }
-  (** Type for inspection of a node *)
+  type html_element := element
 
-  and __element =
+  type element =
     | Null
     | String of string
     | Unsafe of string (* text without encoding *)
-    | Node of __node
-    | List of __element list
+    | Node of {
+        tag : string;
+        attributes : Attribute.t list;
+        children : element list;
+      }
+    | List of element list
 
-  val view : element -> __element
+  val view : html_element -> element
   (** A function to inspect a JSX.element.
 
      {[

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,4 @@
 (library
- (name html_of_jsx)
- (wrapped false)
+ (name JSX)
  (modes :standard melange)
  (public_name html_of_jsx))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,3 @@
 (library
  (name JSX)
- (modes :standard melange)
  (public_name html_of_jsx))

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -283,7 +283,8 @@ let rewrite_jsx =
             match tag.pexp_desc with
             (* div() [@JSX] *)
             | Pexp_ident { txt = Lident name; loc = name_loc }
-              when Html.is_html_element name || Html.is_svg_element name ->
+              when JSX.Html.is_html_element name || JSX.Html.is_svg_element name
+              ->
                 rewrite_node ~loc:name_loc name rest_of_args children
             (* Reason adds `createElement` as default when an uppercase is found,
                we change it back to make *)

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -193,21 +193,16 @@ let transform_labelled ~loc:_parentLoc ~tag_name props (prop_label, value) =
       in
       [%expr [%e attribute_final] :: [%e props]]
 
-let transform_attributes ~loc ~tag_name args =
-  match args with
-  | [] -> [%expr []]
-  | attrs -> (
-      let list_of_attributes =
-        attrs
-        |> List.fold_left
-             ~f:(transform_labelled ~loc ~tag_name)
-             ~init:[%expr []]
-      in
-      match list_of_attributes with
-      | [%expr []] -> [%expr []]
-      | _ ->
-          (* We need to filter attributes since optionals are represented as None *)
-          [%expr List.filter_map Fun.id [%e list_of_attributes]])
+let transform_attributes ~loc ~tag_name attrs =
+  let attrs =
+    List.rev attrs
+    |> List.fold_left ~f:(transform_labelled ~loc ~tag_name) ~init:[%expr []]
+  in
+  match attrs with
+  | [%expr []] -> [%expr []]
+  | attrs ->
+      (* We need to filter attributes since optionals are represented as None *)
+      [%expr List.filter_map Fun.id [%e attrs]]
 
 let rewrite_node ~loc tag_name args children =
   let dom_node_name = estring ~loc tag_name in

--- a/test/Test_without_transformation.ml
+++ b/test/Test_without_transformation.ml
@@ -13,8 +13,8 @@ let string_attributes =
   let a =
     JSX.node "a"
       [
-        JSX.Attribute.String ("target", "_blank");
         JSX.Attribute.String ("href", "google.html");
+        JSX.Attribute.String ("target", "_blank");
       ]
       []
   in
@@ -25,10 +25,10 @@ let bool_attributes =
   let a =
     JSX.node "input"
       [
-        JSX.Attribute.String ("type", "checkbox");
-        JSX.Attribute.String ("name", "cheese");
-        JSX.Attribute.Bool ("checked", true);
         JSX.Attribute.Bool ("disabled", false);
+        JSX.Attribute.Bool ("checked", true);
+        JSX.Attribute.String ("name", "cheese");
+        JSX.Attribute.String ("type", "checkbox");
       ]
       []
   in
@@ -63,8 +63,8 @@ let no_ignore_unkwnown_attributes_on_jsx =
   let div =
     JSX.node "div"
       [
-        JSX.Attribute.String ("key", "uniqueKeyId");
         JSX.Attribute.Bool ("suppressContentEditableWarning", true);
+        JSX.Attribute.String ("key", "uniqueKeyId");
       ]
       []
   in
@@ -112,8 +112,8 @@ let encode_attributes =
   let component =
     JSX.node "div"
       [
-        JSX.Attribute.String ("about", "\' <");
         JSX.Attribute.String ("data-user-path", "what/the/path");
+        JSX.Attribute.String ("about", "\' <");
       ]
       [ JSX.string "& \"" ]
   in
@@ -124,8 +124,8 @@ let encode_attributes =
 let make ~name () =
   JSX.node "button"
     [
-      JSX.Attribute.String ("name", (name : string));
       JSX.Attribute.Event ("onclick", "doFunction('foo');");
+      JSX.Attribute.String ("name", (name : string));
     ]
     []
 
@@ -190,10 +190,10 @@ let render_svg =
   let svg =
     JSX.node "svg"
       [
-        JSX.Attribute.String ("xmlns", "http://www.w3.org/2000/svg");
-        JSX.Attribute.String ("viewBox", "0 0 24 24");
-        JSX.Attribute.String ("width", "24px");
         JSX.Attribute.String ("height", "24px");
+        JSX.Attribute.String ("width", "24px");
+        JSX.Attribute.String ("viewBox", "0 0 24 24");
+        JSX.Attribute.String ("xmlns", "http://www.w3.org/2000/svg");
       ]
       [ path ]
   in

--- a/test/cram/lower.t/run.t
+++ b/test/cram/lower.t/run.t
@@ -48,11 +48,11 @@
         [
           Some(
             [@implicit_arity]
-            JSX.Attribute.String("href", "https://example.com": string),
+            JSX.Attribute.String("tabindex", string_of_int(1: int)),
           ),
           Some(
             [@implicit_arity]
-            JSX.Attribute.String("tabindex", string_of_int(1: int)),
+            JSX.Attribute.String("href", "https://example.com": string),
           ),
         ],
       ),
@@ -130,16 +130,16 @@
                                  [
                                    Some(
                                      [@implicit_arity]
-                                     JSX.Attribute.Event(
-                                       "onclick",
-                                       "console.log": string,
+                                     JSX.Attribute.String(
+                                       "href",
+                                       e.path: string,
                                      ),
                                    ),
                                    Some(
                                      [@implicit_arity]
-                                     JSX.Attribute.String(
-                                       "href",
-                                       e.path: string,
+                                     JSX.Attribute.Event(
+                                       "onclick",
+                                       "console.log": string,
                                      ),
                                    ),
                                  ],
@@ -203,7 +203,7 @@
                 [
                   Some(
                     [@implicit_arity]
-                    JSX.Attribute.String("id", "idimg": string),
+                    JSX.Attribute.String("src", "picture/img.png": string),
                   ),
                   Some(
                     [@implicit_arity]
@@ -211,7 +211,7 @@
                   ),
                   Some(
                     [@implicit_arity]
-                    JSX.Attribute.String("src", "picture/img.png": string),
+                    JSX.Attribute.String("id", "idimg": string),
                   ),
                 ],
               ),
@@ -222,14 +222,14 @@
               List.filter_map(
                 Fun.id,
                 [
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("src", "picture/img1.webp": string),
-                  ),
                   Some(
                     [@implicit_arity]
                     JSX.Attribute.String("type", "image/webp": string),
                   ),
+                  Some(
+                    [@implicit_arity]
+                    JSX.Attribute.String("src", "picture/img1.webp": string),
+                  ),
                 ],
               ),
               [],
@@ -241,11 +241,11 @@
                 [
                   Some(
                     [@implicit_arity]
-                    JSX.Attribute.String("src", "picture/img2.jpg": string),
+                    JSX.Attribute.String("type", "image/jpeg": string),
                   ),
                   Some(
                     [@implicit_arity]
-                    JSX.Attribute.String("type", "image/jpeg": string),
+                    JSX.Attribute.String("src", "picture/img2.jpg": string),
                   ),
                 ],
               ),
@@ -261,8 +261,8 @@
       List.filter_map(
         Fun.id,
         [
-          Some([@implicit_arity] JSX.Attribute.String("dy", "3 4": string)),
           Some([@implicit_arity] JSX.Attribute.String("dx", "1 2": string)),
+          Some([@implicit_arity] JSX.Attribute.String("dy", "3 4": string)),
         ],
       ),
       [],


### PR DESCRIPTION
- Do not reverse attributes at runtime, fix order in ppx. This also makes it so nodes created without ppx have order of attributes preserved, instead of reversed.
- General code cleanup
- Reuse element repr for Debug
