### PR TITLE
Change attributes representation

### DIFF
--- a/lib/JSX.mli
+++ b/lib/JSX.mli
@@ -9,13 +9,8 @@
   ]}
 *)
 
-module Attribute : sig
-  type t =
-    | Bool of (string * bool)
-    | String of (string * string)
-    | Style of string
-    | Event of (string * string)
-end
+type attribute =
+  string * [ `Bool of bool | `Int of int | `Float of float | `String of string ]
 
 type element
 (** The type that represents a JSX.element *)
@@ -45,7 +40,7 @@ val int : int -> element
 val list : element list -> element
 (** Helper to render a list of elements *)
 
-val node : string -> Attribute.t list -> element list -> element
+val node : string -> attribute list -> element list -> element
 (** The function to create a HTML DOM Node [https://developer.mozilla.org/en-US/docs/Web/API/Node]. Given the tag, list of attributes and list of children.
 
   {[
@@ -81,7 +76,7 @@ module Debug : sig
     | Unsafe of string (* text without encoding *)
     | Node of {
         tag : string;
-        attributes : Attribute.t list;
+        attributes : attribute list;
         children : element list;
       }
     | List of element list

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -108,63 +108,55 @@ let make_attribute ~loc ~is_optional ~prop attribute_name attribute_value =
   match (prop, is_optional) with
   | Rich_attribute { type_ = String; _ }, false
   | Attribute { type_ = String; _ }, false ->
-      [%expr
-        Some (JSX.Attribute.String ([%e attribute_name], [%e attribute_value]))]
+      [%expr Some ([%e attribute_name], `String [%e attribute_value])]
   | Rich_attribute { type_ = String; _ }, true
   | Attribute { type_ = String; _ }, true ->
       [%expr
         Stdlib.Option.map
-          (fun v -> JSX.Attribute.String ([%e attribute_name], v))
+          (fun v -> ([%e attribute_name], `String v))
           [%e attribute_value]]
   | Rich_attribute { type_ = Int; _ }, false
   | Attribute { type_ = Int; _ }, false ->
-      [%expr
-        Some
-          (JSX.Attribute.String
-             ([%e attribute_name], string_of_int [%e attribute_value]))]
+      [%expr Some ([%e attribute_name], `Int [%e attribute_value])]
   | Rich_attribute { type_ = Int; _ }, true | Attribute { type_ = Int; _ }, true
     ->
       [%expr
         Stdlib.Option.map
-          (fun v -> JSX.Attribute.String ([%e attribute_name], string_of_int v))
+          (fun v -> ([%e attribute_name], `Int v))
           [%e attribute_value]]
   | Rich_attribute { type_ = Bool; _ }, false
   | Attribute { type_ = Bool; _ }, false ->
-      [%expr
-        Some (JSX.Attribute.Bool ([%e attribute_name], [%e attribute_value]))]
+      [%expr Some ([%e attribute_name], `Bool [%e attribute_value])]
   | Rich_attribute { type_ = Bool; _ }, true
   | Attribute { type_ = Bool; _ }, true ->
       [%expr
         Stdlib.Option.map
-          (fun v -> JSX.Attribute.Bool ([%e attribute_name], v))
+          (fun v -> ([%e attribute_name], `Bool v))
           [%e attribute_value]]
   (* BooleanishString needs to transform bool into string *)
   | Rich_attribute { type_ = BooleanishString; _ }, false
   | Attribute { type_ = BooleanishString; _ }, false ->
       [%expr
-        Some
-          (JSX.Attribute.String
-             ([%e attribute_name], string_of_bool [%e attribute_value]))]
+        Some ([%e attribute_name], `String (string_of_bool [%e attribute_value]))]
   | Rich_attribute { type_ = BooleanishString; _ }, true
   | Attribute { type_ = BooleanishString; _ }, true ->
       [%expr
         Stdlib.Option.map
-          (fun v -> JSX.Attribute.String ([%e attribute_name], v))
+          (fun v -> ([%e attribute_name], `String v))
           string_of_bool [%e attribute_value]]
   | Rich_attribute { type_ = Style; _ }, false
   | Attribute { type_ = Style; _ }, false ->
-      [%expr Some (JSX.Attribute.Style [%e attribute_value])]
+      [%expr Some ("style", `String [%e attribute_value])]
   | Rich_attribute { type_ = Style; _ }, true
   | Attribute { type_ = Style; _ }, true ->
       [%expr
-        Stdlib.Option.map (fun v -> JSX.Attribute.Style v) [%e attribute_value]]
+        Stdlib.Option.map (fun v -> ("style", `String v)) [%e attribute_value]]
   | Event _, false ->
-      [%expr
-        Some (JSX.Attribute.Event ([%e attribute_name], [%e attribute_value]))]
+      [%expr Some ([%e attribute_name], `String [%e attribute_value])]
   | Event _, true ->
       [%expr
         Stdlib.Option.map
-          (fun v -> JSX.Attribute.Event ([%e attribute_name], v))
+          (fun v -> ([%e attribute_name], `String v))
           [%e attribute_value]]
 
 let is_optional = function Optional _ -> true | _ -> false

--- a/test/Test_reason.re
+++ b/test/Test_reason.re
@@ -155,7 +155,7 @@ let onclick_inline_string =
     let div = <div onclick=onClick />;
     assert_string(
       JSX.render(div),
-      {|<div onclick="console.log('clicked')"></div>|},
+      {|<div onclick="console.log(&apos;clicked&apos;)"></div>|},
     );
   });
 

--- a/test/Test_without_transformation.ml
+++ b/test/Test_without_transformation.ml
@@ -5,17 +5,14 @@ let single_empty_tag =
 
 let empty_string_attribute =
   test "empty_string_attribute" @@ fun () ->
-  let div = JSX.node "div" [ JSX.Attribute.String ("class", "") ] [] in
+  let div = JSX.node "div" [ ("class", `String "") ] [] in
   assert_string (JSX.render div) "<div class=\"\"></div>"
 
 let string_attributes =
   test "string_attributes" @@ fun () ->
   let a =
     JSX.node "a"
-      [
-        JSX.Attribute.String ("href", "google.html");
-        JSX.Attribute.String ("target", "_blank");
-      ]
+      [ ("href", `String "google.html"); ("target", `String "_blank") ]
       []
   in
   assert_string (JSX.render a) "<a href=\"google.html\" target=\"_blank\"></a>"
@@ -25,10 +22,10 @@ let bool_attributes =
   let a =
     JSX.node "input"
       [
-        JSX.Attribute.Bool ("disabled", false);
-        JSX.Attribute.Bool ("checked", true);
-        JSX.Attribute.String ("name", "cheese");
-        JSX.Attribute.String ("type", "checkbox");
+        ("disabled", `Bool false);
+        ("checked", `Bool true);
+        ("name", `String "cheese");
+        ("type", `String "checkbox");
       ]
       []
   in
@@ -37,9 +34,7 @@ let bool_attributes =
 
 let truthy_attributes =
   test "truthy_attributes" @@ fun () ->
-  let component =
-    JSX.node "input" [ JSX.Attribute.String ("aria-hidden", "true") ] []
-  in
+  let component = JSX.node "input" [ ("aria-hidden", `String "true") ] [] in
   assert_string (JSX.render component) "<input aria-hidden=\"true\" />"
 
 let self_closing_tag =
@@ -63,8 +58,8 @@ let no_ignore_unkwnown_attributes_on_jsx =
   let div =
     JSX.node "div"
       [
-        JSX.Attribute.Bool ("suppressContentEditableWarning", true);
-        JSX.Attribute.String ("key", "uniqueKeyId");
+        ("suppressContentEditableWarning", `Bool true);
+        ("key", `String "uniqueKeyId");
       ]
       []
   in
@@ -102,7 +97,7 @@ let list =
 let inline_styles =
   test "inline_styles" @@ fun () ->
   let component =
-    JSX.node "button" [ JSX.Attribute.Style "color: red; border: none" ] []
+    JSX.node "button" [ ("style", `String "color: red; border: none") ] []
   in
   assert_string (JSX.render component)
     "<button style=\"color: red; border: none\"></button>"
@@ -111,10 +106,7 @@ let encode_attributes =
   test "encode_attributes" @@ fun () ->
   let component =
     JSX.node "div"
-      [
-        JSX.Attribute.String ("data-user-path", "what/the/path");
-        JSX.Attribute.String ("about", "\' <");
-      ]
+      [ ("data-user-path", `String "what/the/path"); ("about", `String "\' <") ]
       [ JSX.string "& \"" ]
   in
   assert_string (JSX.render component)
@@ -124,8 +116,8 @@ let encode_attributes =
 let make ~name () =
   JSX.node "button"
     [
-      JSX.Attribute.Event ("onclick", "doFunction('foo');");
-      JSX.Attribute.String ("name", (name : string));
+      ("onclick", `String "doFunction('foo');");
+      ("name", `String (name : string));
     ]
     []
 
@@ -133,20 +125,18 @@ let event =
   test "event" @@ fun () ->
   assert_string
     (JSX.render (make ~name:"json" ()))
-    "<button onclick=\"doFunction('foo');\" name=\"json\"></button>"
+    "<button onclick=\"doFunction(&apos;foo&apos;);\" name=\"json\"></button>"
 
 let className =
   test "className" @@ fun () ->
-  let div = JSX.node "div" [ JSX.Attribute.String ("class", "lol") ] [] in
+  let div = JSX.node "div" [ ("class", `String "lol") ] [] in
   assert_string (JSX.render div) "<div class=\"lol\"></div>"
 
 let className_2 =
   test "className_2" @@ fun () ->
   let component =
     JSX.node "div"
-      [
-        JSX.Attribute.String ("class", "flex xs:justify-center overflow-hidden");
-      ]
+      [ ("class", `String "flex xs:justify-center overflow-hidden") ]
       []
   in
   assert_string (JSX.render component)
@@ -177,8 +167,8 @@ let render_svg =
   let path =
     JSX.node "path"
       [
-        JSX.Attribute.String
-          ( "d",
+        ( "d",
+          `String
             "M 5 3 C 3.9069372 3 3 3.9069372 3 5 L 3 19 C 3 20.093063 \
              3.9069372 21 5 21 L 19 21 C 20.093063 21 21 20.093063 21 19 L 21 \
              12 L 19 12 L 19 19 L 5 19 L 5 5 L 12 5 L 12 3 L 5 3 z M 14 3 L 14 \
@@ -190,10 +180,10 @@ let render_svg =
   let svg =
     JSX.node "svg"
       [
-        JSX.Attribute.String ("height", "24px");
-        JSX.Attribute.String ("width", "24px");
-        JSX.Attribute.String ("viewBox", "0 0 24 24");
-        JSX.Attribute.String ("xmlns", "http://www.w3.org/2000/svg");
+        ("height", `String "24px");
+        ("width", `String "24px");
+        ("viewBox", `String "0 0 24 24");
+        ("xmlns", `String "http://www.w3.org/2000/svg");
       ]
       [ path ]
   in

--- a/test/cram/component.t/run.t
+++ b/test/cram/component.t/run.t
@@ -16,11 +16,11 @@ We need to output ML syntax here, otherwise refmt could not parse it.
       [
         JSX.node "div"
           (List.filter_map Fun.id
-             [ Some (JSX.Attribute.String ("class", ("md:w-1/3" : string))) ])
+             [ Some ("class", `String ("md:w-1/3" : string)) ])
           [];
         JSX.node "div"
           (List.filter_map Fun.id
-             [ Some (JSX.Attribute.String ("class", ("md:w-2/3" : string))) ])
+             [ Some ("class", `String ("md:w-2/3" : string)) ])
           [];
       ]
   

--- a/test/cram/lower.t/run.t
+++ b/test/cram/lower.t/run.t
@@ -3,10 +3,7 @@
   let lower_empty_attr =
     JSX.node(
       "div",
-      List.filter_map(
-        Fun.id,
-        [Some([@implicit_arity] JSX.Attribute.String("class", "": string))],
-      ),
+      List.filter_map(Fun.id, [Some(("class", `String("": string)))]),
       [],
     );
   let lower_inline_styles =
@@ -15,11 +12,10 @@
       List.filter_map(
         Fun.id,
         [
-          Some(
-            JSX.Attribute.Style(
-              Style.make(~backgroundColor="gainsboro", ()): string,
-            ),
-          ),
+          Some((
+            "style",
+            `String(Style.make(~backgroundColor="gainsboro", ()): string),
+          )),
         ],
       ),
       [],
@@ -31,9 +27,7 @@
         Fun.id,
         [
           Stdlib.Option.map(
-            v =>
-              [@implicit_arity]
-              JSX.Attribute.String("tabindex", string_of_int(v)),
+            v => ("tabindex", `Int(v)),
             tabindex: option(int),
           ),
         ],
@@ -46,14 +40,8 @@
       List.filter_map(
         Fun.id,
         [
-          Some(
-            [@implicit_arity]
-            JSX.Attribute.String("tabindex", string_of_int(1: int)),
-          ),
-          Some(
-            [@implicit_arity]
-            JSX.Attribute.String("href", "https://example.com": string),
-          ),
+          Some(("tabindex", `Int(1: int))),
+          Some(("href", `String("https://example.com": string))),
         ],
       ),
       [foo],
@@ -68,36 +56,21 @@
       "div",
       List.filter_map(
         Fun.id,
-        [
-          Some(
-            [@implicit_arity]
-            JSX.Attribute.String("class", "flex-container": string),
-          ),
-        ],
+        [Some(("class", `String("flex-container": string)))],
       ),
       [
         JSX.node(
           "div",
           List.filter_map(
             Fun.id,
-            [
-              Some(
-                [@implicit_arity]
-                JSX.Attribute.String("class", "sidebar": string),
-              ),
-            ],
+            [Some(("class", `String("sidebar": string)))],
           ),
           [
             JSX.node(
               "h2",
               List.filter_map(
                 Fun.id,
-                [
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("class", "title": string),
-                  ),
-                ],
+                [Some(("class", `String("title": string)))],
               ),
               ["jsoo-react" |> s],
             ),
@@ -105,12 +78,7 @@
               "nav",
               List.filter_map(
                 Fun.id,
-                [
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("class", "menu": string),
-                  ),
-                ],
+                [Some(("class", `String("menu": string)))],
               ),
               [
                 JSX.node(
@@ -128,20 +96,11 @@
                                List.filter_map(
                                  Fun.id,
                                  [
-                                   Some(
-                                     [@implicit_arity]
-                                     JSX.Attribute.String(
-                                       "href",
-                                       e.path: string,
-                                     ),
-                                   ),
-                                   Some(
-                                     [@implicit_arity]
-                                     JSX.Attribute.Event(
-                                       "onclick",
-                                       "console.log": string,
-                                     ),
-                                   ),
+                                   Some(("href", `String(e.path: string))),
+                                   Some((
+                                     "onclick",
+                                     `String("console.log": string),
+                                   )),
                                  ],
                                ),
                                [e.title |> s],
@@ -163,37 +122,20 @@
       "button",
       List.filter_map(
         Fun.id,
-        [
-          Some(
-            [@implicit_arity]
-            JSX.Attribute.String("class", "FancyButton": string),
-          ),
-        ],
+        [Some(("class", `String("FancyButton": string)))],
       ),
       [children],
     );
   let lower_with_many_props =
     JSX.node(
       "div",
-      List.filter_map(
-        Fun.id,
-        [
-          Some(
-            [@implicit_arity] JSX.Attribute.String("translate", "yes": string),
-          ),
-        ],
-      ),
+      List.filter_map(Fun.id, [Some(("translate", `String("yes": string)))]),
       [
         JSX.node(
           "picture",
           List.filter_map(
             Fun.id,
-            [
-              Some(
-                [@implicit_arity]
-                JSX.Attribute.String("id", "idpicture": string),
-              ),
-            ],
+            [Some(("id", `String("idpicture": string)))],
           ),
           [
             JSX.node(
@@ -201,18 +143,9 @@
               List.filter_map(
                 Fun.id,
                 [
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("src", "picture/img.png": string),
-                  ),
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("alt", "test picture/img.png": string),
-                  ),
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("id", "idimg": string),
-                  ),
+                  Some(("src", `String("picture/img.png": string))),
+                  Some(("alt", `String("test picture/img.png": string))),
+                  Some(("id", `String("idimg": string))),
                 ],
               ),
               [],
@@ -222,14 +155,8 @@
               List.filter_map(
                 Fun.id,
                 [
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("type", "image/webp": string),
-                  ),
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("src", "picture/img1.webp": string),
-                  ),
+                  Some(("type", `String("image/webp": string))),
+                  Some(("src", `String("picture/img1.webp": string))),
                 ],
               ),
               [],
@@ -239,14 +166,8 @@
               List.filter_map(
                 Fun.id,
                 [
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("type", "image/jpeg": string),
-                  ),
-                  Some(
-                    [@implicit_arity]
-                    JSX.Attribute.String("src", "picture/img2.jpg": string),
-                  ),
+                  Some(("type", `String("image/jpeg": string))),
+                  Some(("src", `String("picture/img2.jpg": string))),
                 ],
               ),
               [],
@@ -261,8 +182,8 @@
       List.filter_map(
         Fun.id,
         [
-          Some([@implicit_arity] JSX.Attribute.String("dx", "1 2": string)),
-          Some([@implicit_arity] JSX.Attribute.String("dy", "3 4": string)),
+          Some(("dx", `String("1 2": string))),
+          Some(("dy", `String("3 4": string))),
         ],
       ),
       [],


### PR DESCRIPTION
We change attribute to be represented by:

    type attribute =
      string * [ `Bool of bool
               | `Int of int
               | `Float of float
               | `String of string ]

where we moved special cases for Event and Style (which apparently we not escaped, one might say that these attributes should never be used to put user generated content in and they are right, but better be safe anyway).

The upside is also that this type is a subset of yojson type which might come handly translating JSON into HTML and back.
