### PR TITLE
adding support for object method components

### DIFF
--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -289,6 +289,9 @@ let rewrite_jsx =
             | Pexp_ident id ->
                 rewrite_component ~loc:tag.pexp_loc id rest_of_args children
             | _ -> assert false)
+        | Pexp_apply ({ pexp_desc = Pexp_send _; _ }, _)
+          when has_jsx_attr expr.pexp_attributes ->
+            super#expression expr
         (* div() [@JSX] *)
         | Pexp_apply (_tag, _props) when has_jsx_attr expr.pexp_attributes ->
             raise_errorf ~loc:expr.pexp_loc "tag should be an identifier"

--- a/test/Test_without_transformation.ml
+++ b/test/Test_without_transformation.ml
@@ -195,6 +195,20 @@ let render_svg =
      L 5 3 z M 14 3 L 14 5 L 17.585938 5 L 8.2929688 14.292969 L 9.7070312 \
      15.707031 L 19 6.4140625 L 19 10 L 21 10 L 21 3 L 14 3 z\"></path></svg>"
 
+let obj =
+  object
+    method make () ~children = JSX.node "div" [] [ JSX.string children ]
+  end
+
+(* The point of this test is to verify that --
+ * assuming our jsx provider has properly output the object component
+ * we can process it -- this avoids having to add any mlx files to our test
+ * or having to extend ReasonML *)
+let object_children =
+  test "object_children" @@ fun () ->
+  let str = (obj#make () ~children:"test" [@JSX]) in
+  assert_string (JSX.render str) "<div>test</div>"
+
 let tests =
   ( "render",
     [
@@ -218,4 +232,5 @@ let tests =
       render_with_doc_type;
       render_svg;
       jsx_unsafe;
+      object_children;
     ] )


### PR DESCRIPTION
This is adds support for experimental object-method components as proposed [here](https://github.com/ocaml-mlx/mlx/pull/17)

These would look like this:

`<obj#meth/>` 
or 
`<obj#meth>children</obj#meth>`

The rationale for enabling this pattern is in the linked PR for MLX.

Probably should not be merged until the MLX PR is merged and the syntax is finalized.

