### PR TITLE
Update dune-release-action to v0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         run: opam install dune-release -y
 
       - name: Run dune-release
-        uses: davesnx/dune-release-action@v0.2.0
+        uses: davesnx/dune-release-action@v0.4.0
         with:
           packages: 'html_of_jsx'
           changelog: './CHANGES.md'


### PR DESCRIPTION
Updates `dune-release-action` to [v0.4.0](https://github.com/davesnx/dune-release-action/blob/main/CHANGES.md).

Notable changes since older versions:

- New `pr-preamble-message` input to prepend custom text to the opam-repository PR description
- Fix `publish-message` input (previously passed as an unrecognized `--msg` flag, which failed the publish step when set)
- Action runtime upgraded to Node.js 24
- `dune-release-action/lint` sub-action for branch/PR linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
